### PR TITLE
Remove some todos and dead methods

### DIFF
--- a/M2/Macaulay2/packages/MinimalPrimes.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes.m2
@@ -14,7 +14,6 @@
 --        3. turn strategies into hooks
 --        4. which symbols need to be exported
 --        5. Binomials package should add binomialMinimalPrimes as a strategy to minimalPrimes
---        6. add installMinprimes that gives a warning
 ---------------------------------------------------------------------------
 newPackage(
     "MinimalPrimes",
@@ -67,7 +66,7 @@ newPackage(
 -- .  Document minprimes, something about the strategies
 -- .  Export only the symbols we want
 
-export { "Hybrid", "minimalPrimes", "minprimes" => "minimalPrimes", "radical", "radicalContainment", "installMinprimes" }
+export { "Hybrid", "minimalPrimes", "minprimes" => "minimalPrimes", "radical", "radicalContainment"}
 
 importFrom_Core { "raw", "rawCharSeries", "rawGBContains", "rawRadical", "newMonomialIdeal" }
 importFrom_Core { "isComputationDone", "cacheComputation", "fetchComputation", "updateComputation", "cacheHit", "Context", "Computation" }
@@ -107,9 +106,6 @@ algorithms = new MutableHashTable from {}
 
 -- used for dynamic strategies here and in PrimaryDecomposition
 Hybrid = new SelfInitializingType of List
-
--- deprecate this soon
-installMinprimes = () -> printerr "warning: the installMinprimes routine is now deprecated and should be removed"
 
 --------------------------------------------------------------------
 -- Support routines

--- a/M2/Macaulay2/packages/MinimalPrimes/doc.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/doc.m2
@@ -1,5 +1,3 @@
-undocumented { installMinprimes }
-
 doc ///
 Node
   Key

--- a/M2/Macaulay2/packages/MultiplicitySequence.m2
+++ b/M2/Macaulay2/packages/MultiplicitySequence.m2
@@ -56,8 +56,6 @@ export {
     "printHilbertSequence"
  }
 
--- installMinprimes() -- for MinimalPrimes.m2
-
 getGenElts = method(Options => {symbol minTerms => -1, symbol numCandidates => 3})
 getGenElts (Ideal, ZZ) := List => opts -> (I, n) -> (
     G := flatten entries mingens I; -- I_*;
@@ -737,8 +735,6 @@ installPackage("MultiplicitySequence", RemakeAllDocumentation => true)
 uninstallPackage "MultiplicitySequence"
 check "MultiplicitySequence"
 viewHelp "MultiplicitySequence"
-needsPackage "MinimalPrimes"
-installMinprimes()
 debugLevel = 2
 
 elapsedTime multiplicitySequence I

--- a/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
@@ -430,13 +430,12 @@ Node
       Invent. Math. 110 (1992) 207-235. However, we use @TO (localize, Ideal, Ideal)@.
 
       The @TT "Strategy"@ option value sets the strategy option for @TO localize@, and should be one of the following:
-      -- TODO: The default value is 2.
 
       @UL{
-	  LI ("Strategy => 0", " -- Uses ", TT "localize", " Strategy 0"),
-	  LI ("Strategy => 1", " -- Uses ", TT "localize", " Strategy 1"),
-	  LI ("Strategy => 2", " -- Uses ", TT "localize", " Strategy 2")
-	  }@
+          LI ("Strategy => 0", " -- Uses ", TO "localize", " Strategy 0"),
+          LI ("Strategy => 1", " -- Uses ", TO "localize", " Strategy 1"),
+          LI ("Strategy => 2", " -- Uses ", TO "localize", " Strategy 2 - default")
+      }@
 
       The @TT "Increment"@ option value should be an integer. The algorithm given in
       Eisenbud-Huneke-Vasconcelos, Invent. Math. 110 (1992) 207-235, relies on @TT "topComponents(I + P^m)"@

--- a/M2/Macaulay2/packages/RandomPoints.m2
+++ b/M2/Macaulay2/packages/RandomPoints.m2
@@ -69,8 +69,6 @@ export {
     }
 exportMutable {}
 
---installMinprimes();
-
 --this appears to need to be here, otherwise the options don't realize dimViaBezout is a function, it thinks its a symbol.
 dimViaBezout=method(Options => {
     Verbose => false, 


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->

* remove undocumented and deprecated `installMinprimes` from MinimalPrimes package.
* document default strategy for primary decomposition algorithm and udpate to links for usability.

Hopefully @mahroud can validate correctness of removing installMinPrimes as his comments suggest it is correct.

Address some issues in https://github.com/users/aalmousa/projects/2/views/1?pane=issue&itemId=4328562171&issue=aalmousa%7CM2%7C41

