### PR TITLE
Document strategy better for primary decomposition

### DIFF
--- a/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
@@ -130,7 +130,7 @@ Node
       this can be specified by passing a @TT "Hybrid"@ Strategy in the form
 
       @UL {
-        {TT "Hybrid{primaryDecompisition.Stategy, localize.Strategy}"}
+        {TT "Hybrid{primaryDecompisition.Strategy, localize.Strategy}"}
       }@
     Example
       kk = ZZ/3

--- a/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
@@ -118,6 +118,27 @@ Node
       I == intersect C
       #C
     Text
+      This function has one optional input @TT "Strategy"@, which accepts three
+      possible values used to determine the algorithm for finding embedded components.
+      @UL {
+        {TT("Res"), " - This strategy is closest to the original Eisenbud-Huneke-Vasconcelos method."},
+        {TT "Hom"},
+        {TT "Sat"},
+      }@
+
+      If you want to specify the @TT "Strategy"@ to be used by @TO localize@ as well,
+      this can be specified by passing a @TT "Hybrid"@ Strategy in the form
+
+      @UL {
+        {TT "Hybrid{primaryDecompisition.Stategy, localize.Strategy}"}
+      }@
+
+      While the default (and typically fastest) strategy is @TT "Sat"@, it is recommended to try different
+      @TT "Strategy"@ values if the computation of a particular embedded component is taking too long.
+      One can start the computation with one strategy, and interrupt and resume with a different strategy
+      (even multiple times) if desired.
+
+    Text
       Recall that @TO "Macaulay2Doc :: List / Function"@ applies a function to each element of a
       list, returning the results as a list. This is often useful with lists of ideals,
       such as the list @TT "C"@ of primary components.
@@ -131,8 +152,8 @@ Node
     Example
       associatedPrimes I / print;
   Caveat
-    -- FIXME
-    The ground ring must be a prime field.
+    Some strategies require the ground ring to be a prime field but results can
+    be obtained in some cases even for more general ground rings.
   SeeAlso
     (primaryDecomposition, Module)
     (associatedPrimes, Ideal)
@@ -213,15 +234,14 @@ Node
       known primary components. To display detailed information throughout the computation, set the global variable
       @TO "debugLevel"@ to a value greater than 0, e.g. @TT "debugLevel=1"@ (or @TT "debugLevel=2"@ for even more detail).
 
-      This function has one optional input @TT "Strategy"@, which accepts 3
+      This function has one optional input @TT "Strategy"@, which accepts three
       possible values that determine the algorithm for finding embedded components.
 
--- FIXME
       @UL {
-	  {TT "Res", PARA {"This strategy is closest to the original Eisenbud-Huneke-Vasconcelos method."}},
-	  {TT "Hom"},
-	  {TT "Sat"},
-	  }@
+        {TT("Hybrid{Res}"), " - This strategy is closest to the original Eisenbud-Huneke-Vasconcelos method."},
+        {TT "Hybrid{Hom}"},
+        {TT "Hybrid{Sat}"},
+      }@
 
       While the default (and typically fastest) strategy is @TT "Sat"@, it is recommended to try different
       @TT "Strategy"@ values if the computation of a particular embedded component is taking too long.

--- a/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition/doc.m2
@@ -132,12 +132,16 @@ Node
       @UL {
         {TT "Hybrid{primaryDecompisition.Stategy, localize.Strategy}"}
       }@
-
+    Example
+      kk = ZZ/3
+      R = kk[a,b]
+      I = ideal {a^2, a*b}
+      primaryDecomposition(I, Strategy => Hybrid{Res, 1})
+    Text
       While the default (and typically fastest) strategy is @TT "Sat"@, it is recommended to try different
       @TT "Strategy"@ values if the computation of a particular embedded component is taking too long.
       One can start the computation with one strategy, and interrupt and resume with a different strategy
       (even multiple times) if desired.
-
     Text
       Recall that @TO "Macaulay2Doc :: List / Function"@ applies a function to each element of a
       list, returning the results as a list. This is often useful with lists of ideals,
@@ -151,9 +155,14 @@ Node
       and can be obtained by using @TO (associatedPrimes, Ideal)@.
     Example
       associatedPrimes I / print;
-  Caveat
-    Some strategies require the ground ring to be a prime field but results can
-    be obtained in some cases even for more general ground rings.
+    Text
+      Some strategies require the ground ring to be a prime field but results can
+      be obtained in some cases even for more general ground rings.
+    Example
+      kk = GF(9)
+      R = kk[a,b]
+      I = ideal {a^2, a*b}
+      primaryDecomposition(I)
   SeeAlso
     (primaryDecomposition, Module)
     (associatedPrimes, Ideal)


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->

This clarifies the documentation of Strategy option for the Ideal / Module forms of the primaryDecomposition method. It also removes a FIXME in the documentation related to the requirement that the ground field be a prime ring and updates the documentation a bit. 

I am adding some examples as well. 

Will close https://github.com/users/aalmousa/projects/2/views/1?pane=issue&itemId=4328562171&issue=aalmousa%7CM2%7C41 when merged.