### PR TITLE
Missed variable name change in tensor doc examples

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/tensor-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/tensor-doc.m2
@@ -470,7 +470,7 @@ doc ///
       R = kk[a, b, c]
       I = ideal (a, b); A = I/I^2
       J = ideal (b, c); B = J/J^2
-      K = ideal (a, c); F = K/K^2
+      K = ideal (a, c); C = K/K^2
       T =  A_0 ** (B_0 ** C_0)
       T' = (A_0 ** B_0) ** C_0
       assert(tensorAssociativity(A, B, C) * T == T')


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->

When editing this new example before submitting it I failed to update all the variable names as I was tweaking things. This example fails to build but this fixes it.