### PR TITLE
kernel docs updates

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
@@ -107,6 +107,8 @@ Description
     @TT "SubringLimit => n"@ -- an option for @TO kernel@ which
     causes the computation of the kernel of a ring map to stop after @TT "n"@
     elements have been discovered.
+Caveat
+  Used only for computing the kernel of a @TO RingMap@.
 ///
 
 
@@ -120,6 +122,8 @@ Description
     @TT "DegreeLimit => d"@ -- an option for @TO kernel@ which
     causes the computation of the kernel of a ring map to stop after generators for the degree @TT "d"@
     part of the kernel have been discovered.
+Caveat
+  Used only for computing the kernel of a @TO RingMap@.
 ///
 
 
@@ -131,6 +135,8 @@ Headline
 Description
   Text
     This option is passed through to @TO gb@ when computing the kernel of a @TT "RingMap"@.
+Caveat
+  Used only for computing the kernel of a @TO RingMap@.
 SeeAlso
   gb
 ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
@@ -40,15 +40,15 @@ doc ///
     Example
       R = QQ[a..d];
       S = QQ[s,t];
-      -- F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
-      -- ker F
+      F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
+      ker F
     Text
       Passing @TT "SubringLimit"@ stops the computation early.
     Example
       R = QQ[a..d];
-      -- S = QQ[s,t];
-      -- F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
-      -- ker(F, SubringLimit => 1)
+      S = QQ[s,t];
+      F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
+      ker(F, SubringLimit => 1)
     Text
       In the case when everything is homogeneous, Hilbert functions are used to speed up the computations.
   Caveat

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
@@ -106,7 +106,7 @@ Description
   Text
     @TT "SubringLimit => n"@ -- an option for @TO kernel@ which
     causes the computation of the kernel of a ring map to stop after @TT "n"@
-    elements have been discovered."
+    elements have been discovered.
 ///
 
 
@@ -117,9 +117,9 @@ Headline
     stop after finding enough elements of a subring
 Description
   Text
-    @TT "DegreeLimit => n"@ -- an option for @TO kernel@ which
-    causes the computation of the kernel of a ring map to stop after generators for the degree @TT "n"@
-    part of the kernel have been discovered."
+    @TT "DegreeLimit => d"@ -- an option for @TO kernel@ which
+    causes the computation of the kernel of a ring map to stop after generators for the degree @TT "d"@
+    part of the kernel have been discovered.
 ///
 
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
@@ -1,13 +1,3 @@
--- -*- coding: utf-8 -*-
---- status: TODO
---- author(s): 
---- notes: 
-
-undocumented {
-    [kernel, DegreeLimit],
-    [kernel, Strategy],
-}
-
 doc ///
 Node
   Key
@@ -25,70 +15,122 @@ Node
     syz
 ///
 
-document { 
-     Key => (kernel,RingMap),
-     Headline => "kernel of a ringmap",
-     Usage => "kernel f",
-     Inputs => {
-	  "f" => {TT "R", " --> ", TT "S"},
-	  SubringLimit => ZZ => "stop the computation after this many elements of the kernel have been found"
-	  },
-     Outputs => {
-	  Ideal => {"an ideal of ", TT "R"}
-	  },
-     EXAMPLE lines ///
-	  R = QQ[a..d];
-	  S = QQ[s,t];
-	  F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
-	  ker F
-	  G = map(S,R,{s^5, s^3*t^2-t, s*t-s, t^5})
-	  ker(G, SubringLimit=>1)
-	  ///,
-     "In the case when everything is homogeneous, Hilbert functions are
-     used to speed up the computations.",
-     Caveat => {"It should be possible to interrupt the computation and restart it, but this has
-	  not yet been implemented."},
-     SeeAlso => {"substitution and maps between rings", "elimination of variables", monomialCurveIdeal},
-     Subnodes => { TO [kernel, SubringLimit] },
-     }
-
-document { 
-     Key => {(kernel,Matrix),
-	  (kernel, RingElement)},
-     Headline => "kernel of a map of modules",
-     Usage => "kernel f, kernel a",
-     Inputs => {
-	  "f" => {"a map of modules ", TT "M --> N"}
-	  },
-     Outputs => {
-	  Module => {"the kernel of f, a submodule of M"}
-	  },
-     PARA{},
-     "The kernel is the submodule of M of all elements mapping to zero under ", TT "f", ".",
-     "If f is a RingElement it is interpreted as a 1 by 1 matrix",".",
-     EXAMPLE lines ///
-     	  R = ZZ/32003[a,b]/(ideal(a,b))^3
-	  M = R^1/(ideal a^2)
-	  mat = matrix{{a^2,b^2},{b,a}}
-	  ker mat
-          presentation ker mat
-	  syz mat
-          f = map(M++M, M++M, mat)
-	  ker f
-	  ///,
-     SeeAlso => {syz, 
-	         cokernel,
-		 image,
-		 map,
-		 matrix
-		 }
-	  }
-     
+doc ///
+  Key
+    (kernel, RingMap)
+  Headline
+    kernel of a ringmap
+  Usage
+    kernel f
+  Inputs
+    f:RingMap
+      $f: R \rightarrow S$
+    SubringLimit => ZZ
+      stop the computation after this many elements of the kernel have been found.
+    DegreeLimit => ZZ
+      stop the computation after generators for the kernel in this degree have been found
+    Strategy => String
+      Groebner basis computation strategy. See @TO gb@.
+  Outputs
+    :Ideal
+      an ideal of $R$
+  Description
+    Text
+      The twisted cubic.
+    Example
+      R = QQ[a..d];
+      S = QQ[s,t];
+      -- F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
+      -- ker F
+    Text
+      Passing @TT "SubringLimit"@ stops the computation early.
+    Example
+      R = QQ[a..d];
+      -- S = QQ[s,t];
+      -- F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
+      -- ker(F, SubringLimit => 1)
+    Text
+      In the case when everything is homogeneous, Hilbert functions are used to speed up the computations.
+  Caveat
+    It should be possible to interrupt the computation and restart it, but this has not yet been implemented.
+  SeeAlso
+    "substitution and maps between rings"
+    "elimination of variables"
+    monomialCurveIdeal
+  Subnodes
+    kernel
+    SubringLimit
+    DegreeLimit
+    Strategy
+///
 
 document {
-    Key => [kernel, SubringLimit],
-    Headline => "stop after finding enough elements of a subring",
-    TT "SubringLimit => n", " -- an option for ", TO "kernel", " which
-    causes the computation of the kernel of a ring map to stop after ", TT "n", "
-    elements have been discovered."
+  Key => {(kernel,Matrix),
+  (kernel, RingElement)},
+  Headline => "kernel of a map of modules",
+  Usage => "kernel f, kernel a",
+  Inputs => {
+    "f" => {"a map of modules ", TT "M --> N"}
+  },
+  Outputs => {
+    Module => {"the kernel of f, a submodule of M"}
+  },
+  PARA{},
+  "The kernel is the submodule of M of all elements mapping to zero under ", TT "f", ".",
+  "If f is a RingElement it is interpreted as a 1 by 1 matrix",".",
+  EXAMPLE lines ///
+    R = ZZ/32003[a,b]/(ideal(a,b))^3
+    M = R^1/(ideal a^2)
+    mat = matrix{{a^2,b^2},{b,a}}
+    ker mat
+    presentation ker mat
+    syz mat
+    f = map(M++M, M++M, mat)
+    ker f
+  ///,
+  SeeAlso => {
+    syz,
+    cokernel,
+    image,
+    map,
+    matrix
+  }
 }
+
+doc ///
+Key
+  [kernel, SubringLimit]
+Headline
+    stop after finding enough elements of a subring
+Description
+  Text
+    @TT "SubringLimit => n"@ -- an option for @TO kernel@ which
+    causes the computation of the kernel of a ring map to stop after @TT "n"@
+    elements have been discovered."
+///
+
+
+doc ///
+Key
+  [kernel, DegreeLimit]
+Headline
+    stop after finding enough elements of a subring
+Description
+  Text
+    @TT "DegreeLimit => n"@ -- an option for @TO kernel@ which
+    causes the computation of the kernel of a ring map to stop after generators for the degree @TT "n"@
+    part of the kernel have been discovered."
+///
+
+
+doc ///
+Key
+  [kernel, Strategy]
+Headline
+  strategy for Groebner Basis computations used in kernel computations
+Description
+  Text
+    This option is passed through to @TO gb@ when computing the kernel of a @TT "RingMap"@.
+SeeAlso
+  gb
+///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/kernel-doc.m2
@@ -48,7 +48,8 @@ doc ///
       R = QQ[a..d];
       S = QQ[s,t];
       F = map(S,R,{s^3, s^2*t, s*t^2, t^3})
-      ker(F, SubringLimit => 1)
+      K = ker(F, SubringLimit => 1)
+      assert(numgens K == 1)
     Text
       In the case when everything is homogeneous, Hilbert functions are used to speed up the computations.
   Caveat

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/tensor-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/tensor-doc.m2
@@ -470,7 +470,7 @@ doc ///
       R = kk[a, b, c]
       I = ideal (a, b); A = I/I^2
       J = ideal (b, c); B = J/J^2
-      K = ideal (a, c); F = K/K^2
+      K = ideal (a, c); C = K/K^2
       T =  A_0 ** (B_0 ** C_0)
       T' = (A_0 ** B_0) ** C_0
       assert(tensorAssociativity(A, B, C) * T == T')


### PR DESCRIPTION
Add documentation nodes for optional arguments "Strategy" and "DegreeLimit" for kernel ring map.  Simplify and clarify examples for kernel(RingMap).

Addresses one bullet in https://github.com/users/aalmousa/projects/2/views/1?pane=issue&itemId=4328563959&issue=aalmousa%7CM2%7C49