### PR TITLE
docs: add package landing example for QthPower

### DIFF
--- a/M2/Macaulay2/packages/QthPower.m2
+++ b/M2/Macaulay2/packages/QthPower.m2
@@ -960,7 +960,18 @@ document {
           Also this package contains the extension to examples over the rationals; 
 	  which, in turn, allows for quicker answers over ZZ/q for most large q,
 	  which can be produced if desired merely by changing the coefficient ring from QQ to ZZ/q."
-	  }
+	  },
+     PARA {
+	  "Start with a small finite-field example to compute an integral closure and inspect the size of the returned presentation."
+	  },
+     EXAMPLE lines ///
+          wtR = matrix{{5,6,6},{3,6,0}};
+          Rq = ZZ/23[u,v,w,Weights=>entries weightGrevlex(wtR)];
+          GB = {u^6+u^3*w-v^3*w^2};
+          (numerators,relicR,icR,wticR) = qthIntegralClosure(wtR,Rq,GB);
+          (#numerators, numgens ideal relicR)
+          ///,
+     SeeAlso => {qthIntegralClosure, rationalIntegralClosure, qthConductor, weightGrevlex}
      }
 --------------------------------------------------------------------------------------------------------
 document {
@@ -1380,8 +1391,6 @@ wtR13 = matrix{{25,21}};
 --ic3 = qthIntegralClosure(ic2#0,ic2#1,ic2#2)--------------------------------
 --assert(ic3#3 == matrix{{16,15,13,12,11,10,7}}------------------------------
 ///
-
-
 
 
 


### PR DESCRIPTION
## Summary
- add a package-level starter example to the \ landing page
- add or tighten top-level navigation for the touched docs node
- keep the change scoped to one issue and one package file

## Verification
- \


Closes #336